### PR TITLE
SHOPWEDO_HOST correctie

### DIFF
--- a/src/Shopwedo/ShopwedoClient.php
+++ b/src/Shopwedo/ShopwedoClient.php
@@ -12,7 +12,7 @@ use GuzzleHttp\Psr7;
  */
 class ShopwedoClient
 {
-    const SHOPWEDO_HOST = 'https://shopwedo.com/admin/api/';
+    const SHOPWEDO_HOST = 'https://admin.shopwedo.com/api/';
 
     protected $client;
 


### PR DESCRIPTION
Wegens verhuis van de ShopWeDo "admin" & front-site is het huidige API-eindpunt op een nieuwe URL belandt.
Het oude onder "admin/api" zal zeer mogelijk niet meer werken vanaf 1-1-2019.