### PR TITLE
Update host url

### DIFF
--- a/src/Shopwedo/ShopwedoClient.php
+++ b/src/Shopwedo/ShopwedoClient.php
@@ -12,7 +12,7 @@ use GuzzleHttp\Psr7;
  */
 class ShopwedoClient
 {
-    const SHOPWEDO_HOST = 'https://admin.shopwedo.com/api/';
+    const SHOPWEDO_HOST = 'https://api.shopwedo.app/';
 
     protected $client;
 


### PR DESCRIPTION
We have received a message that the url is changing. Here is a PR with the correct url.

Official message:
"De afgelopen maanden hebben wij grote infrastructurele IT-aanpassingen gedaan om onze servers en applicaties nog schaalbaarder te maken. Dit gaat gepaard met een aanpassing van de domeinnaam waarop de app werkt.
Een belangrijke update voor u als API gebruiker is dat er vanaf heden een nieuwe URL beschikbaar is: api.shopwedo.app
Gelieve de url zo snel mogelijk langs uw kant aan te passen en dit graag voor 1 september 2024.
Daarna zal de oude url niet meer beschikbaar zijn. "